### PR TITLE
Port aus dem Environment laden

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+ppl-auth
+

--- a/main.go
+++ b/main.go
@@ -3,11 +3,16 @@ package main
 import (
 	"fmt"
 	"net/http"
+	"os"
 )
 
 func main() {
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = "8080"
+	}
 	http.HandleFunc("/", hello)
-	err := http.ListenAndServe(":80", nil)
+	err := http.ListenAndServe(":"+port, nil)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
Der Server lauscht auf dem Port, der in der Umgebungsvariable PORT definiert wird. Ist diese nicht gesetzt, wird stattdessen Port 8080 verwendet.