### PR TITLE
Login mit Passwort für Mitarbeiter

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -46,9 +46,18 @@
   ]
   revision = "0677bdde3e15a69060c33fac24fd53044b4694b8"
 
+[[projects]]
+  branch = "master"
+  name = "golang.org/x/crypto"
+  packages = [
+    "bcrypt",
+    "blowfish"
+  ]
+  revision = "027cca12c2d63e3d62b670d901e8a2c95854feec"
+
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "1c82b1e5e957c070bd58fb08baa4280dae5199b411cfde333c3f25f90a5b7c14"
+  inputs-digest = "4e4590d545aa660018370eaa808c144000d4c714a70f28108b63a9cfa6da5aab"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/api/api.go
+++ b/api/api.go
@@ -11,8 +11,8 @@ var ApiHandler *handler.Handler
 
 func init() {
 	schema, err := graphql.NewSchema(graphql.SchemaConfig{
-		Query: QueryType,
-		// Mutation: MutationType,
+		Query:    QueryType,
+		Mutation: MutationType,
 	})
 	if err != nil {
 		log.Fatal(err)

--- a/api/mutation.go
+++ b/api/mutation.go
@@ -1,0 +1,30 @@
+package api
+
+import (
+	"github.com/graphql-go/graphql"
+	"github.com/ob-vss-ss18/ppl-auth/backend"
+)
+
+var MutationType = graphql.NewObject(graphql.ObjectConfig{
+	Name: "Mutations",
+	Fields: graphql.Fields{
+		"loginPwd": &graphql.Field{
+			Type: UserType,
+			Args: graphql.FieldConfigArgument{
+				"email": &graphql.ArgumentConfig{
+					Description: "E-Mail address",
+					Type:        graphql.NewNonNull(graphql.String),
+				},
+				"password": &graphql.ArgumentConfig{
+					Description: "Password",
+					Type:        graphql.NewNonNull(graphql.String),
+				},
+			},
+			Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+				email := p.Args["email"].(string)
+				passwd := p.Args["password"].(string)
+				return backend.LoginPwd(email, passwd)
+			},
+		},
+	},
+})

--- a/api/user_type.go
+++ b/api/user_type.go
@@ -13,5 +13,11 @@ var UserType = graphql.NewObject(graphql.ObjectConfig{
 		"email": &graphql.Field{
 			Type: graphql.NewNonNull(graphql.String),
 		},
+		"role": &graphql.Field{
+			Type: graphql.NewNonNull(graphql.String),
+		},
+		"token": &graphql.Field{
+			Type: graphql.String,
+		},
 	},
 })

--- a/backend/user.go
+++ b/backend/user.go
@@ -1,6 +1,10 @@
 package backend
 
-import "errors"
+import (
+	"errors"
+
+	"golang.org/x/crypto/bcrypt"
+)
 
 type User struct {
 	ID    int    `json:"id"`
@@ -40,6 +44,23 @@ func RemoveUserByID(id int) error {
 	return err
 }
 
-func LoginPwd(email string, password string) (*User, error) {
-	return nil, errors.New("Not implemented")
+func generateToken(userID int) (*User, error) {
+	return nil, errors.New("generateToken not implemented")
+}
+
+func LoginPwd(email string, passwd string) (*User, error) {
+	var id int
+	var hash string
+	err := db.QueryRow(`SELECT users.user_id, password.password
+		FROM users
+		INNER JOIN password
+		ON users.user_id = password.user_id
+		WHERE users.email=$1 AND users.role IN ('staff', 'owner')`, email).Scan(&id, &hash)
+	if err != nil {
+		return nil, err
+	}
+	if err = bcrypt.CompareHashAndPassword([]byte(hash), []byte(passwd)); err != nil {
+		return nil, errors.New("Wrong password")
+	}
+	return generateToken(id)
 }

--- a/backend/user.go
+++ b/backend/user.go
@@ -1,8 +1,12 @@
 package backend
 
+import "errors"
+
 type User struct {
 	ID    int    `json:"id"`
 	Email string `json:"email"`
+	Role  string `json:"role"`
+	Token string `json:"token"`
 }
 
 func InsertUser(user *User) error {
@@ -34,4 +38,8 @@ func GetUserByID(id int) (*User, error) {
 func RemoveUserByID(id int) error {
 	_, err := db.Exec("DELETE FROM users WHERE id=$1", id)
 	return err
+}
+
+func LoginPwd(email string, password string) (*User, error) {
+	return nil, errors.New("Not implemented")
 }

--- a/backend/user.go
+++ b/backend/user.go
@@ -1,7 +1,10 @@
 package backend
 
 import (
+	"crypto/rand"
+	"encoding/base64"
 	"errors"
+	"time"
 
 	"golang.org/x/crypto/bcrypt"
 )
@@ -44,8 +47,38 @@ func RemoveUserByID(id int) error {
 	return err
 }
 
-func generateToken(userID int) (*User, error) {
-	return nil, errors.New("generateToken not implemented")
+func generateRandomString() (string, error) {
+	b := make([]byte, 30)
+	_, err := rand.Read(b)
+	if err != nil {
+		return "", err
+	}
+	return base64.URLEncoding.EncodeToString(b), nil
+}
+
+func generateToken(userID int, validFor int) (*User, error) {
+	var id int
+	var user User
+	token, err := generateRandomString()
+	expiry := time.Now().UTC().Unix() + int64(validFor)
+	if err != nil {
+		return nil, err
+	}
+	err = db.QueryRow(`INSERT INTO token(token, user_id, expiry_date)
+		VALUES ($1, $2, $3)
+		RETURNING token_id`, token, userID, expiry).Scan(&id)
+	if err != nil {
+		return nil, err
+	}
+	err = db.QueryRow(`SELECT users.user_id, users.email, users.role, token.token
+		FROM token
+		INNER JOIN users
+		ON token.user_id = users.user_id
+		WHERE token_id = $1`, id).Scan(&user.ID, &user.Email, &user.Role, &user.Token)
+	if err != nil {
+		return nil, err
+	}
+	return &user, nil
 }
 
 func LoginPwd(email string, passwd string) (*User, error) {
@@ -55,12 +88,12 @@ func LoginPwd(email string, passwd string) (*User, error) {
 		FROM users
 		INNER JOIN password
 		ON users.user_id = password.user_id
-		WHERE users.email=$1 AND users.role IN ('staff', 'owner')`, email).Scan(&id, &hash)
+		WHERE users.email = $1 AND users.role IN ('staff', 'owner')`, email).Scan(&id, &hash)
 	if err != nil {
 		return nil, err
 	}
 	if err = bcrypt.CompareHashAndPassword([]byte(hash), []byte(passwd)); err != nil {
 		return nil, errors.New("Wrong password")
 	}
-	return generateToken(id)
+	return generateToken(id, 7*24*60*60)
 }


### PR DESCRIPTION
Mit der Mutation `loginPwd` können sich Mitarbeiter (Rolle STAFF oder OWNER) jetzt mit ihrer E-Mailadresse und ihrem Passwort einen Token erzeugen, der später zur Autorisierung bei den einzelnen Operationen genutzt werden kann.

Closes #13 