### PR TITLE
Implement request token

### DIFF
--- a/api/mutation.go
+++ b/api/mutation.go
@@ -26,5 +26,18 @@ var MutationType = graphql.NewObject(graphql.ObjectConfig{
 				return backend.LoginPwd(email, passwd)
 			},
 		},
+		"requestToken": &graphql.Field{
+			Type: graphql.Boolean,
+			Args: graphql.FieldConfigArgument{
+				"email": &graphql.ArgumentConfig{
+					Description: "E-Mail address",
+					Type:        graphql.NewNonNull(graphql.String),
+				},
+			},
+			Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+				email := p.Args["email"].(string)
+				return backend.RequestToken(email)
+			},
+		},
 	},
 })

--- a/backend/user.go
+++ b/backend/user.go
@@ -97,3 +97,19 @@ func LoginPwd(email string, passwd string) (*User, error) {
 	}
 	return generateToken(id, 7*24*60*60)
 }
+
+func RequestToken(email string) (bool, error) {
+	var id int
+	err := db.QueryRow(`SELECT users.user_id
+		FROM users
+		WHERE users.email = $1`, email).Scan(&id)
+	if err != nil {
+		return false, err
+	}
+	_, err = generateToken(id, 30*60)
+	if err == nil {
+		return true, err
+	} else {
+		return false, err
+	}
+}


### PR DESCRIPTION
Mit der Mutation requestToken können sich Kunden(Rolle CUSTOMER) mit ihrer E-Mailadresse einen Token erzeugen lassen, der später zur Autorisierung bei den einzelnen Operationen genutzt werden kann.

Closes #14 